### PR TITLE
Get serial of virtio devices, trim whitespace from vpd_pg80 serial

### DIFF
--- a/quickscan/quickscan/devices.py
+++ b/quickscan/quickscan/devices.py
@@ -156,7 +156,7 @@ class BaseDevice:
 
             elif key == 'vpd_pg80':
                 key = 'serial'
-                content = ''.join([ch for ch in content if ch in string.printable])
+                content = ''.join([ch for ch in content if ch in string.printable]).strip()
 
             self.sys_api[key] = content
 

--- a/quickscan/quickscan/devices.py
+++ b/quickscan/quickscan/devices.py
@@ -34,7 +34,9 @@ class BaseDevice:
         'removable',
         'size',
         'ro',
+        'serial',
         'device/model',
+        'device/serial',
         'device/vendor',
         'device/wwid',
         'device/vpd_pg80',
@@ -157,6 +159,9 @@ class BaseDevice:
             elif key == 'vpd_pg80':
                 key = 'serial'
                 content = ''.join([ch for ch in content if ch in string.printable]).strip()
+
+            if key == 'serial' and content == 'unknown':
+                continue
 
             self.sys_api[key] = content
 


### PR DESCRIPTION
Two tweaks here:

1) virtio devices don't have /sys/block/$dev/device/vpd_pg80, but *do* have /sys/block/$dev/serial, so let's try to get the serial number from the latter if it's there, and use device/vpd_pg80 if it's not.  Without this, on a test VM with /dev/vda, /dev/vdb and /dev/vdc, quickscan ends up thinking those are all the same device, because all they have is a vendor string (no model or serial to uniquely identify them).

2) The serial number from /sys/block/$dev/device/vpd_pg80 picks up a bunch of leading whitespace when run on my openSUSE Tumbleweed desktop system.  We should probably strip that.

Signed-off-by: Tim Serong <tserong@suse.com>